### PR TITLE
Multiplex cache

### DIFF
--- a/src/spikegadgets_to_nwb/convert_ephys.py
+++ b/src/spikegadgets_to_nwb/convert_ephys.py
@@ -129,9 +129,13 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
         time_index = np.arange(self._get_maxshape()[0])[selection_list[0]]
         data = []
         i = time_index[0]
+        stream_count = 0
         while i < min(time_index[-1], self._get_maxshape()[0]):
             # find the stream where this piece of slice begins
             io_stream = np.argmin(i >= file_start_ind) - 1
+            # clear cache if starting a new stream
+            if stream_count > 0:
+                self.neo_io[io_stream - 1].get_analogsignal_multiplexed.cache_clear()
             # get the data from that stream
             data.extend(
                 (
@@ -151,19 +155,14 @@ class RecFileDataChunkIterator(GenericDataChunkIterator):
                     )
                 )
             )
-            print(
-                "added",
-                self.n_time[io_stream]
-                - (i - file_start_ind[io_stream]),  # if added up to the end of stream
-                time_index[-1] - i,  # if finished in this stream
-            )
             i += min(
                 self.n_time[io_stream]
                 - (i - file_start_ind[io_stream]),  # if added up to the end of stream
                 time_index[-1] - i,  # if finished in this stream
             )
-        data = (np.array(data) * self.conversion).astype("int16")
+            stream_count += 1
 
+        data = (np.array(data) * self.conversion).astype("int16")
         return data
 
     def _get_maxshape(self) -> Tuple[int, int]:

--- a/src/spikegadgets_to_nwb/spike_gadgets_raw_io.py
+++ b/src/spikegadgets_to_nwb/spike_gadgets_raw_io.py
@@ -12,6 +12,7 @@ from neo.rawio.baserawio import (
 import numpy as np
 from scipy.stats import linregress
 from xml.etree import ElementTree
+import functools
 
 
 class SpikeGadgetsRawIO(BaseRawIO):
@@ -93,7 +94,10 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
         self._sampling_rate = float(hconf.attrib["samplingRate"])
         num_ephy_channels = int(hconf.attrib["numChannels"])
-        num_chan_per_chip = int(sconf.attrib["chanPerChip"])
+        try:
+            num_chan_per_chip = int(sconf.attrib["chanPerChip"])
+        except KeyError:
+            num_chan_per_chip = 32  # default value
 
         # explore sub stream and count packet size
         # first bytes is 0x55
@@ -435,6 +439,7 @@ class SpikeGadgetsRawIO(BaseRawIO):
         raw_uint64 = raw_uint8.flatten().view(dtype=np.int64)
         return raw_uint64
 
+    @functools.lru_cache(maxsize=None)
     def get_analogsignal_multiplexed(self, channel_names=None) -> dict[str, np.ndarray]:
         if channel_names is None:
             # read all multiplexed channels


### PR DESCRIPTION
Addresses Issue #39 by caching the full epoch of multiplexed data previously created by each call to get_analogsignal_multiplexed. 