### PR TITLE
add system to fill dropped timestamps of ephys data

### DIFF
--- a/src/spikegadgets_to_nwb/convert.py
+++ b/src/spikegadgets_to_nwb/convert.py
@@ -127,7 +127,7 @@ def _create_nwb(
 
     logger.info("CREATING REC DATA ITERATORS")
     # make generic rec file data chunk iterator to pass to functions
-    rec_dci = RecFileDataChunkIterator(rec_filepaths)
+    rec_dci = RecFileDataChunkIterator(rec_filepaths, interpolate_dropped_packets=True)
 
     rec_header = read_header(rec_filepaths[0])
     reconfig_header = rec_header

--- a/src/spikegadgets_to_nwb/spike_gadgets_raw_io.py
+++ b/src/spikegadgets_to_nwb/spike_gadgets_raw_io.py
@@ -19,7 +19,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
     extensions = ["rec"]
     rawmode = "one-file"
 
-    def __init__(self, filename="", selected_streams=None):
+    def __init__(
+        self, filename="", selected_streams=None, interpolate_dropped_packets=False
+    ):
         """
         Class for reading spikegadgets files.
         Only continuous signals are supported at the moment.
@@ -34,10 +36,13 @@ class SpikeGadgetsRawIO(BaseRawIO):
                 useful for spikeextractor when one stream only is needed.
                 For instance streams = ['ECU', 'trodes']
                 'trodes' is name for ephy channel (ntrodes)
+            interpolate_dropped_packets: bool
+                If True, interpolates single dropped packets in the analog data.
         """
         BaseRawIO.__init__(self)
         self.filename = filename
         self.selected_streams = selected_streams
+        self.interpolate_dropped_packets = interpolate_dropped_packets
 
     def _source_name(self):
         return self.filename
@@ -349,6 +354,9 @@ class SpikeGadgetsRawIO(BaseRawIO):
         self.header["spike_channels"] = spike_channels
         self.header["event_channels"] = event_channels
 
+        # initialize interpolate index as none so can check if it has been set in a trodes timestamps call
+        self.interpolate_index = None
+
         self._generate_minimal_annotations()
         # info from GlobalConfiguration in xml are copied to block and seg annotations
         bl_ann = self.raw_annotations["blocks"][0]
@@ -365,6 +373,8 @@ class SpikeGadgetsRawIO(BaseRawIO):
         return t_stop
 
     def _get_signal_size(self, block_index, seg_index, stream_index):
+        if self.interpolate_dropped_packets and self.interpolate_index is None:
+            raise ValueError("interpolate_index must be set before calling this")
         size = self._raw_memmap.shape[0]
         return size
 
@@ -428,11 +438,14 @@ class SpikeGadgetsRawIO(BaseRawIO):
             i_start:i_stop, self._timestamp_byte : self._timestamp_byte + 4
         ]
         raw_uint32 = raw_uint8.flatten().view("uint32")
-        diff = np.diff(raw_uint32)
-        if len(set(diff)) != 1:
-            raise UserWarning(
-                f"Trodes timestamps are not evenly spaced. {np.sum(diff>1)} instances of dropped packets."
-            )
+        if self.interpolate_dropped_packets and self.interpolate_index is None:
+            self.interpolate_index = np.where(np.diff(raw_uint32) == 2)[
+                0
+            ]  # find locations of single dropped packets
+            self._interpolate_raw_memmap()  # interpolates in the memmap
+            return self.get_analogsignal_timestamps(
+                i_start, i_stop
+            )  # call again to get the interpolated timestamps
         return raw_uint32
 
     def get_sys_clock(self, i_start, i_stop):
@@ -563,11 +576,14 @@ class SpikeGadgetsRawIO(BaseRawIO):
 
         return dio_change_times, change_dir_trim
 
-    def get_regressed_systime(self, i_start, i_stop):
+    def get_regressed_systime(self, i_start, i_stop=None):
         NANOSECONDS_PER_SECOND = 1e9
+        if i_stop is None:
+            i_stop = self._raw_memmap.shape[0]
         # get values
-        systime = self.get_sys_clock(i_start, i_stop)
         trodestime = self.get_analogsignal_timestamps(i_start, i_stop)
+        trodestime = self.insert_dropped_trodestime(trodestime)
+        systime = self.get_sys_clock(i_start, i_stop)
         # Convert
         systime_seconds = np.asarray(systime).astype(np.float64)
         trodestime_index = np.asarray(trodestime).astype(np.float64)
@@ -576,10 +592,46 @@ class SpikeGadgetsRawIO(BaseRawIO):
         adjusted_timestamps = intercept + slope * trodestime_index
         return (adjusted_timestamps) / NANOSECONDS_PER_SECOND
 
-    def get_systime_from_trodes_timestamps(self, i_start, i_stop):
+    def get_systime_from_trodes_timestamps(self, i_start, i_stop=None):
         MILLISECONDS_PER_SECOND = 1e3
+        if i_stop is None:
+            i_stop = self._raw_memmap.shape[0]
         # get values
-        trodestime = self.get_analogsignal_timestamps(i_start, i_stop)
+        trodestime = self.insert_dropped_trodestime(
+            self.get_analogsignal_timestamps(i_start, i_stop)
+        )
         return (trodestime - int(self.timestamp_at_creation)) * (
             1.0 / self._sampling_rate
         ) + int(self.system_time_at_creation) / MILLISECONDS_PER_SECOND
+
+    def insert_dropped_trodestime(self, timestamps):
+        """Inserts timestamps for dropped packets in the trodestime timestamps.
+        Parameters
+        ----------
+        timestamps : np.ndarray
+            The timestamps to insert dropped timestamps into.
+        Returns
+        -------
+        np.ndarray
+            The timestamps with dropped timestamps inserted.
+        """
+        if self.interpolate_dropped_packets:
+            timestamps = np.insert(
+                timestamps,
+                self.interpolate_index,
+                timestamps[self.interpolate_index] + 1,
+            )
+        return timestamps
+
+    def _interpolate_raw_memmap(
+        self,
+    ):
+        """Interpolates single dropped packets in the analog data."""
+        if self.interpolate_dropped_packets:
+            # duplicates dropped packets in the raw memmap
+            self._raw_memmap = np.insert(
+                self._raw_memmap,
+                self.interpolate_index,
+                self._raw_memmap[self.interpolate_index],
+                axis=0,
+            )

--- a/src/spikegadgets_to_nwb/tests/test_spikegadgets_io.py
+++ b/src/spikegadgets_to_nwb/tests/test_spikegadgets_io.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+
+from spikegadgets_to_nwb.spike_gadgets_raw_io import SpikeGadgetsRawIO
+
+import numpy as np
+
+path = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_spikegadgets_raw_io_interpolation():
+    # Interpolation of dropped timestamp only done for ephys data and systime
+
+    # get the path to the rec file
+    try:
+        # running on github
+        data_path = Path(os.environ.get("DOWNLOAD_DIR"))
+    except (TypeError, FileNotFoundError):
+        # running locally
+        data_path = Path(path + "/test_data")
+    rec_file = data_path / "20230622_sample_01_a1.rec"
+
+    # create the SpikeGadgetsRawIO object
+    neo_io = SpikeGadgetsRawIO(
+        rec_file, interpolate_dropped_packets=True
+    )  # unaltered file
+    neo_io_dropped = SpikeGadgetsRawIO(
+        rec_file, interpolate_dropped_packets=True
+    )  # dropped packet file
+
+    # parse the header
+    neo_io.parse_header()
+    neo_io_dropped.parse_header()
+
+    # manually edit the memap to remove the second packet
+    neo_io_dropped._raw_memmap = np.delete(neo_io._raw_memmap, 1, axis=0)
+
+    # get the trodes timestamps from each to compare
+    trodes_timestamps = neo_io.get_analogsignal_timestamps(0, 10)
+    trodes_timestamps_dropped = neo_io_dropped.get_analogsignal_timestamps(0, 10)
+    assert len(trodes_timestamps) == len(trodes_timestamps_dropped)
+    assert np.isclose(
+        trodes_timestamps[2:], trodes_timestamps_dropped[2:], atol=1e-6, rtol=0
+    ).all()
+    assert trodes_timestamps[0] == trodes_timestamps_dropped[1]
+    # make sure systime behaves expectedly
+    systime = neo_io.get_sys_clock(0, 10)
+    systime_dropped = neo_io_dropped.get_sys_clock(0, 10)
+    assert len(systime) == len(systime_dropped)
+    assert np.isclose(systime[2:], systime_dropped[2:], atol=1e-6, rtol=0).all()
+    assert systime[0] == systime_dropped[1]
+    # get ephys data and check
+    channel = "1"
+    ephys_data = neo_io.get_analogsignal_chunk(
+        i_start=0,
+        i_stop=10,
+        channel_ids=[channel],
+        block_index=0,
+        seg_index=0,
+        stream_index=3,
+    )
+    ephys_data_dropped = neo_io_dropped.get_analogsignal_chunk(
+        i_start=0,
+        i_stop=10,
+        channel_ids=[channel],
+        block_index=0,
+        seg_index=0,
+        stream_index=3,
+    )
+    assert len(ephys_data) == len(ephys_data_dropped)
+    assert np.isclose(ephys_data[2:], ephys_data_dropped[2:], atol=1e-6, rtol=0).all()
+    assert ephys_data[0] == ephys_data_dropped[1]


### PR DESCRIPTION
Addresses issue #15.  For ephys data, will fill single dropped timestamp values with the previous data value.

Functionality is slightly different than default option of rec_to_nwb which would do linear interpolation over the single dropped frame.  However, this way lets you operate on the raw_memmap directly without worrying about views, which I think is faster runtime with minimal change in functionality