### PR TITLE
Fix missing source_script_file_name

### DIFF
--- a/src/spikegadgets_to_nwb/convert_yaml.py
+++ b/src/spikegadgets_to_nwb/convert_yaml.py
@@ -94,6 +94,7 @@ def initialize_nwb(metadata: dict, first_epoch_config: ElementTree) -> NWBFile:
         # notes=self.link_to_notes, TODO
         experiment_description=metadata["experiment_description"],
         source_script="spikegadgets_to_nwb " + __version__,
+        source_script_file_name="convert.py",
     )
     return nwbfile
 


### PR DESCRIPTION
I forgot that `source_script_file_name` is required in NWB if `source_script` is provided. This PR sets `source_script_file_name="convert.py"

Warning:
```
src/spikegadgets_to_nwb/tests/test_convert_position.py::test_add_position
  /Users/rly/mambaforge/envs/spikegadgets_to_nwb/lib/python3.11/site-packages/hdmf/build/objectmapper.py:671: MissingRequiredBuildWarning: NWBFile 'root' is missing required value for attribute 'source_script_file_name'.
    warnings.warn(msg, MissingRequiredBuildWarning)
```