### PR TITLE
Handle cases where uint32 wrapping prevents use of digitize

### DIFF
--- a/src/spikegadgets_to_nwb/convert_position.py
+++ b/src/spikegadgets_to_nwb/convert_position.py
@@ -62,7 +62,7 @@ def wrapped_digitize(
     """
     wrap_point = find_wrap_point(bins)
     if wrap_point is None:
-        return np.digitize(x, bins)
+        return np.digitize(x, bins, right=True)
     ind_first = np.digitize(x, bins[:wrap_point], right=True)
     ind_second = np.digitize(x, bins[wrap_point:], right=True) + wrap_point
     section = (x < bins[0]).astype(int)  # True if in the second section (post-wrap)

--- a/src/spikegadgets_to_nwb/convert_position.py
+++ b/src/spikegadgets_to_nwb/convert_position.py
@@ -31,7 +31,7 @@ def find_wrap_point(t):
     wrap_point = None
     rng = [0, len(t) - 1]
     while t[rng[1]] <= t[rng[0]]:
-        mid = int(np.mean(rng))
+        mid = np.mean(rng, dtype=int)
         if t[mid] <= t[rng[0]]:
             rng[1] = mid
         else:
@@ -58,7 +58,7 @@ def wrapped_digitize(
     Returns
     -------
     np.ndarray
-        digitized indeces
+        digitized indices
     """
     wrap_point = find_wrap_point(bins)
     if wrap_point is None:

--- a/src/spikegadgets_to_nwb/convert_position.py
+++ b/src/spikegadgets_to_nwb/convert_position.py
@@ -15,6 +15,60 @@ from scipy.stats import linregress
 NANOSECONDS_PER_SECOND = 1e9
 
 
+def find_wrap_point(t):
+    """
+    Finds the point at which the timestamps wrap around due to overflow.
+    Returns None if no wrap point is found
+    Parameters
+    ----------
+    t : np.ndarray
+        Array of timestamps
+    Returns
+    -------
+    wrap_point : int
+        Index of the wrap point
+    """
+    wrap_point = None
+    rng = [0, len(t) - 1]
+    while t[rng[1]] <= t[rng[0]]:
+        mid = int(np.mean(rng))
+        if t[mid] <= t[rng[0]]:
+            rng[1] = mid
+        else:
+            rng[0] = mid
+        if rng[0] == rng[1]:
+            wrap_point = rng[0] + 1
+            break
+    return wrap_point
+
+
+def wrapped_digitize(
+    x,
+    bins,
+):
+    """Digitize a location with timestamps that wrap around due to overflow.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        indeces to digitize
+    bins : np.ndarray
+        bins to digitize into
+
+    Returns
+    -------
+    np.ndarray
+        digitized indeces
+    """
+    wrap_point = find_wrap_point(bins)
+    if wrap_point is None:
+        return np.digitize(x, bins)
+    ind_first = np.digitize(x, bins[:wrap_point], right=True)
+    ind_second = np.digitize(x, bins[wrap_point:], right=True) + wrap_point
+    section = (x < bins[0]).astype(int)  # True if in the second section (post-wrap)
+    return ind_first * (1 - section) + ind_second * section
+
+
 def parse_dtype(fieldstr: str) -> np.dtype:
     """
     Parses the last fields parameter (<time uint32><...>) as a single string.
@@ -536,7 +590,7 @@ def get_position_timestamps(
         is_valid_camera_time = np.isin(video_timestamps.index, sample_count)
 
         camera_systime = rec_dci_timestamps[
-            np.digitize(video_timestamps.index[is_valid_camera_time], sample_count)
+            wrapped_digitize(video_timestamps.index[is_valid_camera_time], sample_count)
         ]
         (
             dio_camera_timestamps,

--- a/src/spikegadgets_to_nwb/tests/test_convert_position.py
+++ b/src/spikegadgets_to_nwb/tests/test_convert_position.py
@@ -35,6 +35,8 @@ def test_wrapped_digitize():
     bins = np.array([4, 5, 6, 0, 1, 2])
     expected = np.array([0, 1, 2, 3, 4, 5])
     assert np.array_equal(wrapped_digitize(x, bins), expected)
+    # test case no wrapping
+    assert np.array_equal(wrapped_digitize(expected, expected), expected)
 
 
 def test_parse_dtype_standard():

--- a/src/spikegadgets_to_nwb/tests/test_convert_position.py
+++ b/src/spikegadgets_to_nwb/tests/test_convert_position.py
@@ -7,10 +7,9 @@ import pytest
 from pynwb import NWBHDF5IO, TimeSeries
 
 from spikegadgets_to_nwb import convert, convert_rec_header, convert_yaml
-from spikegadgets_to_nwb.convert_ephys import RecFileDataChunkIterator
-from spikegadgets_to_nwb.convert_intervals import add_sample_count
 from spikegadgets_to_nwb.convert_dios import add_dios
-from spikegadgets_to_nwb.convert_intervals import add_epochs
+from spikegadgets_to_nwb.convert_ephys import RecFileDataChunkIterator
+from spikegadgets_to_nwb.convert_intervals import add_epochs, add_sample_count
 from spikegadgets_to_nwb.convert_position import (
     add_position,
     correct_timestamps_for_camera_to_mcu_lag,
@@ -19,15 +18,23 @@ from spikegadgets_to_nwb.convert_position import (
     estimate_camera_time_from_mcu_time,
     estimate_camera_to_mcu_lag,
     find_acquisition_timing_pause,
+    find_camera_dio_channel,
     find_large_frame_jumps,
     get_framerate,
     parse_dtype,
     read_trodes_datafile,
     remove_acquisition_timing_pause_non_ptp,
-    find_camera_dio_channel,
+    wrapped_digitize,
 )
 from spikegadgets_to_nwb.data_scanner import get_file_info
 from spikegadgets_to_nwb.tests.utils import data_path
+
+
+def test_wrapped_digitize():
+    x = np.array([4, 5, 6, 0, 1, 2])
+    bins = np.array([4, 5, 6, 0, 1, 2])
+    expected = np.array([0, 1, 2, 3, 4, 5])
+    assert np.array_equal(wrapped_digitize(x, bins), expected)
 
 
 def test_parse_dtype_standard():


### PR DESCRIPTION
Addresses #59 by leaving the sample trodes_timestamps as-is, but fixing index lookup of sample count in non-ptp cases of `add_position`